### PR TITLE
减少不必要的重复查询，优化查询速度

### DIFF
--- a/fate.go
+++ b/fate.go
@@ -255,6 +255,7 @@ func (f *fateImpl) getWugeName(name chan<- *Name) (e error) {
 	}()
 	var f1s []*Character
 	var f2s []*Character
+	fsa := map[int][]*Character{}
 	for l := range lucky {
 		if f.config.FilterMode == config.FilterModeCustom {
 			//TODO
@@ -278,24 +279,36 @@ func (f *fateImpl) getWugeName(name chan<- *Name) (e error) {
 		if f.debug {
 			log.Infow("lucky", "l1", l.LastStroke1, "l2", l.LastStroke2, "f1", l.FirstStroke1, "f2", l.FirstStroke2)
 		}
-		if f.config.Regular {
-			f1s, e = f.db.GetCharacters(Stoker(l.FirstStroke1, Regular()))
+		if fsa[l.FirstStroke1] == nil {
+			if f.config.Regular {
+				f1s, e = f.db.GetCharacters(Stoker(l.FirstStroke1, Regular()))
+			} else {
+				f1s, e = f.db.GetCharacters(Stoker(l.FirstStroke1))
+			}
+
+			if e != nil {
+				return Wrap(e, "first stroke1 error")
+			}
+
+			fsa[l.FirstStroke1] = f1s
 		} else {
-			f1s, e = f.db.GetCharacters(Stoker(l.FirstStroke1))
+			f1s = fsa[l.FirstStroke1]
 		}
 
-		if e != nil {
-			return Wrap(e, "first stroke1 error")
-		}
+		if fsa[l.FirstStroke2] == nil {
+			if f.config.Regular {
+				f2s, e = f.db.GetCharacters(Stoker(l.FirstStroke2, Regular()))
+			} else {
+				f2s, e = f.db.GetCharacters(Stoker(l.FirstStroke2))
+			}
 
-		if f.config.Regular {
-			f2s, e = f.db.GetCharacters(Stoker(l.FirstStroke2, Regular()))
+			if e != nil {
+				return Wrap(e, "first stoke2 error")
+			}
+
+			fsa[l.FirstStroke2] = f2s
 		} else {
-			f2s, e = f.db.GetCharacters(Stoker(l.FirstStroke2))
-		}
-
-		if e != nil {
-			return Wrap(e, "first stoke2 error")
+			f2s = fsa[l.FirstStroke2]
 		}
 
 		for _, f1 := range f1s {


### PR DESCRIPTION
笔画数量最多只有32个，将相同笔画查出来的结果缓存起来，可以减少查询次数